### PR TITLE
Add a querystring param to hide the media controls

### DIFF
--- a/src/components/game.jsx
+++ b/src/components/game.jsx
@@ -67,12 +67,14 @@ class Game extends React.Component {
               rows={this.props.grid.height}
               highlightedSnake={this.props.highlightedSnake}
             />
-            <MediaControls
-              toggleGamePause={this.props.toggleGamePause}
-              stepBackwardFrame={this.props.stepBackwardFrame}
-              stepForwardFrame={this.props.stepForwardFrame}
-              paused={this.props.paused}
-            />
+            {this.props.options.hideMediaControls !== "true" && (
+              <MediaControls
+                toggleGamePause={this.props.toggleGamePause}
+                stepBackwardFrame={this.props.stepBackwardFrame}
+                stepForwardFrame={this.props.stepForwardFrame}
+                paused={this.props.paused}
+              />
+            )}
           </BoardWrapper>
           {this.props.options.hideScoreboard !== "true" && (
             <ScoreboardWrapper>


### PR DESCRIPTION
Add `hideMediaControls=true` to the URL querystring params for a board and the media control buttons will be hidden from view.