### PR TITLE
Allow turn number to be specified in querystring params

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -52,7 +52,8 @@ export const fetchFrames = () => {
     const {
       autoplay,
       engine: engineUrl,
-      game: gameId
+      game: gameId,
+      turn
     } = getState().engineOptions;
 
     dispatch(requestFrames());
@@ -68,10 +69,18 @@ export const fetchFrames = () => {
       if (frame.Turn === 0) {
         const frame = getState().frames[0];
         dispatch(setCurrentFrame(frame));
+
         if (autoplay) {
           dispatch(resumeGame());
           dispatch(playFromFrame(frame));
         }
+      }
+
+      // Only navigate to the specified frame if it is within the
+      // amount of frames available in the game
+      if (turn && turn <= getState().frames.length) {
+        const frame = getState().frames[turn];
+        dispatch(setCurrentFrame(frame));
       }
     });
   };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -47,6 +47,11 @@ export const highlightSnake = snakeId => ({
   snakeId
 });
 
+const windowPostMessage = msg => {
+  // Uses postMessage API to send data to the parent frame
+  window.parent.postMessage(msg, "*");
+};
+
 export const fetchFrames = () => {
   return async (dispatch, getState) => {
     const {
@@ -70,6 +75,7 @@ export const fetchFrames = () => {
       // Workaround to render the first frame into the board
       if (frame.Turn === 0) {
         const frame = getState().frames[0];
+        windowPostMessage({ turn: frame.turn });
         dispatch(setCurrentFrame(frame));
 
         if (autoplay) {
@@ -122,6 +128,7 @@ export const reloadGame = () => {
 export const toggleGamePause = () => {
   return async (dispatch, getState) => {
     const { currentFrame, gameStatus, paused, engineOptions } = getState();
+
     if (paused) {
       if (gameStatus === "stopped") {
         await fetchGameStart(engineOptions.engine, engineOptions.game);
@@ -131,6 +138,7 @@ export const toggleGamePause = () => {
       dispatch(resumeGame());
       dispatch(playFromFrame(currentFrame));
     } else {
+      windowPostMessage({ turn: currentFrame.turn + 1 });
       dispatch(pauseGame());
     }
   };
@@ -139,8 +147,10 @@ export const toggleGamePause = () => {
 export const stepForwardFrame = () => {
   return async (dispatch, getState) => {
     const { currentFrame, frames } = getState();
-    const stepToFrame = getFrameByTurn(frames, currentFrame.turn + 1);
+    const nextFrame = currentFrame.turn + 1;
+    const stepToFrame = getFrameByTurn(frames, nextFrame);
     if (stepToFrame) {
+      windowPostMessage({ turn: stepToFrame.turn });
       dispatch(setCurrentFrame(stepToFrame));
     }
   };
@@ -149,8 +159,10 @@ export const stepForwardFrame = () => {
 export const stepBackwardFrame = () => {
   return async (dispatch, getState) => {
     const { currentFrame, frames } = getState();
-    const stepToFrame = getFrameByTurn(frames, currentFrame.turn - 1);
+    const prevFrame = currentFrame.turn - 1;
+    const stepToFrame = getFrameByTurn(frames, prevFrame);
     if (stepToFrame) {
+      windowPostMessage({ turn: stepToFrame.turn });
       dispatch(setCurrentFrame(stepToFrame));
     }
   };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -56,6 +56,8 @@ export const fetchFrames = () => {
       turn
     } = getState().engineOptions;
 
+    const gameTurn = parseInt(turn);
+
     dispatch(requestFrames());
 
     await streamAllFrames(engineUrl, gameId, (game, frame) => {
@@ -78,8 +80,8 @@ export const fetchFrames = () => {
 
       // Only navigate to the specified frame if it is within the
       // amount of frames available in the game
-      if (turn && turn <= getState().frames.length) {
-        const frame = getState().frames[turn];
+      if (gameTurn && gameTurn <= getState().frames.length) {
+        const frame = getState().frames[gameTurn];
         dispatch(setCurrentFrame(frame));
       }
     });


### PR DESCRIPTION
`turn=<number>` will start the game at the specified turn number rather than zero. Only accepts numbers and ignores strings and unicode characters.