### PR TITLE
Allow framerate to be accepted in querystring params

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -96,14 +96,15 @@ export const fetchFrames = () => {
 
 export const playFromFrame = frame => {
   return async (dispatch, getState) => {
+    const { frameRate } = getState().engineOptions;
     const frames = getState().frames.slice(); // Don't modify in place
     const frameIndex = frames.indexOf(frame);
     const slicedFrames = frames.slice(frameIndex);
 
     for (const frame of slicedFrames) {
       if (getState().paused) return;
-      await delay(50);
       dispatch(setCurrentFrame(frame));
+      await delay(frameRate || 50);
     }
 
     const lastFrame = slicedFrames[slicedFrames.length - 1];

--- a/src/utils/engine-client.js
+++ b/src/utils/engine-client.js
@@ -3,7 +3,6 @@ import { makeQueryString, httpToWsProtocol, join } from "./url";
 import { loadSvgs, getSvg } from "./inline-svg";
 import { isLastFrameOfGame } from "./game-state";
 
-const SNAKE_MIN_DELAY_MILLIS = 50;
 const DEFAULT_SNAKE_HEAD = "tongue";
 const DEFAULT_SNAKE_TAIL = "bolt";
 
@@ -12,7 +11,7 @@ async function get(url, query) {
   return fetchResult.json();
 }
 
-export function delay(millis = SNAKE_MIN_DELAY_MILLIS) {
+export function delay(millis) {
   return new Promise(resolve => setTimeout(resolve, millis));
 }
 
@@ -89,10 +88,6 @@ function getSnakeTailSvgUrl(path) {
 }
 
 async function prepareFrame(frame) {
-  // Make sure SVGs are loaded and wait for at least minimum delay time.
-  // const delayPromise = delay(SNAKE_MIN_DELAY_MILLIS);
-  // const svgPromise = setHeadAndTailSvgs(frame.Snakes);
-  // await Promise.all([delayPromise, svgPromise]);
   await setHeadAndTailSvgs(frame.Snakes);
 }
 


### PR DESCRIPTION
`frameRate=<millis>` can be accepted in querystring params now. It accepts a value in milliseconds, defaults to 50 ms which has been the current default for awhile now.

Note: 1000 milliseconds = 1 second delay between frames.

Also changed the frame delay logic so the first frame isn't delayed anymore.