### PR TITLE
[Issue 198] Support rounded-corner snake body parts

### DIFF
--- a/src/components/grid.jsx
+++ b/src/components/grid.jsx
@@ -130,6 +130,30 @@ function getTailTransform(direction, viewBox) {
   }
 }
 
+function checkIfCornerPart(snake, part, partIndex) {
+  // If head or tail of the snake, then false
+  if (partIndex === 0 || partIndex === snake.body.length - 1) return false;
+
+  const ahead = snake.body[partIndex - 1];
+  const behind = snake.body[partIndex + 1];
+
+  // Return false if the behind part has the same position as the current.
+  // Relevant for when the snake initially spawns.
+  if (behind.x === part.x && behind.y === part.y) return false;
+
+  return ahead.direction !== behind.direction;
+}
+
+function determineCornerType(snake, partIndex) {
+  // If head or tail of the snake, then false
+  if (partIndex === 0 || partIndex === snake.body.length - 1) return false;
+
+  const ahead = snake.body[partIndex - 1];
+  const behind = snake.body[partIndex + 1];
+
+  return `${ahead.direction} ${behind.direction}`;
+}
+
 class Grid extends React.Component {
   renderPart(snake, snakeIndex, part, partIndex, highlightedSnake) {
     switch (part.type) {
@@ -138,13 +162,23 @@ class Grid extends React.Component {
       case "tail":
         return this.renderTailPart(snake, snakeIndex, part, highlightedSnake);
       default:
-        return this.renderMiddlePart(
-          snake,
-          snakeIndex,
-          part,
-          partIndex,
-          highlightedSnake
-        );
+        if (checkIfCornerPart(snake, part, partIndex)) {
+          return this.renderCornerPart(
+            snake,
+            snakeIndex,
+            part,
+            partIndex,
+            highlightedSnake
+          );
+        } else {
+          return this.renderMiddlePart(
+            snake,
+            snakeIndex,
+            part,
+            partIndex,
+            highlightedSnake
+          );
+        }
     }
   }
 
@@ -196,6 +230,75 @@ class Grid extends React.Component {
         fill={snake.color}
         shapeRendering="optimizeSpeed"
       />
+    );
+  }
+
+  renderCornerPart(snake, snakeIndex, part, partIndex, highlighted) {
+    if (!part.shouldRender) {
+      return (
+        <svg
+          key={`part${snakeIndex},${part.x},${part.y}`}
+          shapeRendering="optimizeSpeed"
+        />
+      );
+    }
+
+    let viewBox, transform;
+    let path = "M0,0 h40 a60,60 0 0 1 61,60 v81 h-101 z";
+
+    switch (part.direction) {
+      case "left":
+      case "right":
+        viewBox = "0 0 120 100";
+        break;
+      case "up":
+      case "down":
+      default:
+        viewBox = "0 0 100 120";
+        break;
+    }
+
+    switch (determineCornerType(snake, partIndex)) {
+      case "down left":
+        transform = "scale(-1,1) translate(-100, 0)";
+        break;
+      case "left down":
+        transform = "rotate(90,0,0) translate(0,-120)";
+        break;
+      case "right down":
+        transform = "rotate(90,0,0) scale(1,-1)";
+        break;
+      case "up right":
+        transform = "scale(1,-1) translate(0,-120)";
+        break;
+      case "up left":
+        transform = "scale(-1,-1) translate(-100,-120)";
+        break;
+      case "right up":
+        transform = "rotate(-90,0,0) translate(-100,0)";
+        break;
+      case "left up":
+        transform = "rotate(-90,0,0) scale(1,-1) translate(-100,-120)";
+        break;
+      case "down right":
+      default:
+        break;
+    }
+
+    return (
+      <svg
+        key={`part${snakeIndex},${part.x},${part.y}`}
+        x={getPartXOffset(part)}
+        y={getPartYOffset(part)}
+        width={getPartWidth(part)}
+        height={getPartHeight(part)}
+        opacity={getOpacity(snake, highlighted)}
+        fill={snake.color}
+        viewBox={viewBox}
+        shapeRendering="optimizeSpeed"
+      >
+        <path d={path} transform={transform} />
+      </svg>
     );
   }
 

--- a/src/components/grid.jsx
+++ b/src/components/grid.jsx
@@ -130,28 +130,28 @@ function getTailTransform(direction, viewBox) {
   }
 }
 
-function checkIfCornerPart(snake, part, partIndex) {
+function checkIfCornerPart(snake, partIndex) {
   // If head or tail of the snake, then false
   if (partIndex === 0 || partIndex === snake.body.length - 1) return false;
 
-  const ahead = snake.body[partIndex - 1];
   const behind = snake.body[partIndex + 1];
+  const current = snake.body[partIndex];
 
   // Return false if the behind part has the same position as the current.
   // Relevant for when the snake initially spawns.
-  if (behind.x === part.x && behind.y === part.y) return false;
+  if (behind.x === current.x && behind.y === current.y) return false;
 
-  return ahead.direction !== behind.direction;
+  return behind.direction !== current.direction;
 }
 
 function determineCornerType(snake, partIndex) {
   // If head or tail of the snake, then false
   if (partIndex === 0 || partIndex === snake.body.length - 1) return false;
 
-  const ahead = snake.body[partIndex - 1];
   const behind = snake.body[partIndex + 1];
+  const current = snake.body[partIndex];
 
-  return `${ahead.direction} ${behind.direction}`;
+  return `${current.direction} ${behind.direction}`;
 }
 
 class Grid extends React.Component {
@@ -162,7 +162,7 @@ class Grid extends React.Component {
       case "tail":
         return this.renderTailPart(snake, snakeIndex, part, highlightedSnake);
       default:
-        if (checkIfCornerPart(snake, part, partIndex)) {
+        if (checkIfCornerPart(snake, partIndex)) {
           return this.renderCornerPart(
             snake,
             snakeIndex,


### PR DESCRIPTION
# Summary

Rounded corners for issue [198](https://github.com/battlesnakeio/roadmap/issues/198).

<img width="572" alt="screenshot 2019-02-10 13 17 30" src="https://user-images.githubusercontent.com/3220620/52539761-a0c10900-2d36-11e9-91bf-d096970585de.png">

**Note**: There is an unresolved issue of small gaps between body parts. I've tried a number of solutions with nothing really working well. The lines also appear/disappear depending on the browser zoom. Example:

<img width="337" alt="screenshot 2019-02-10 13 17 14" src="https://user-images.githubusercontent.com/3220620/52539788-0614fa00-2d37-11e9-9c8f-b6f5a9518a66.png">


