### PR TITLE
Fix for hiding Scoreboard component properly

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -19,3 +19,244 @@ body {
   font-weight: 400;
   line-height: 1.15;
 }
+
+/*!
+ * Load Awesome v1.1.0 (http://github.danielcardoso.net/load-awesome/)
+ * Copyright 2015 Daniel Cardoso <@DanielCardoso>
+ * Licensed under MIT
+ */
+.la-ball-grid-beat,
+.la-ball-grid-beat > div {
+  position: relative;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.la-ball-grid-beat {
+  display: block;
+  font-size: 0;
+  color: #fff;
+}
+
+.la-ball-grid-beat.la-dark {
+  color: #333;
+}
+
+.la-ball-grid-beat > div {
+  display: inline-block;
+  float: none;
+  background-color: currentColor;
+  border: 0 solid currentColor;
+}
+
+.la-ball-grid-beat {
+  width: 36px;
+  height: 36px;
+}
+
+.la-ball-grid-beat > div {
+  width: 8px;
+  height: 8px;
+  margin: 2px;
+  border-radius: 100%;
+  -webkit-animation-name: ball-grid-beat;
+  -moz-animation-name: ball-grid-beat;
+  -o-animation-name: ball-grid-beat;
+  animation-name: ball-grid-beat;
+  -webkit-animation-iteration-count: infinite;
+  -moz-animation-iteration-count: infinite;
+  -o-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+}
+
+.la-ball-grid-beat > div:nth-child(1) {
+  -webkit-animation-duration: 0.65s;
+  -moz-animation-duration: 0.65s;
+  -o-animation-duration: 0.65s;
+  animation-duration: 0.65s;
+  -webkit-animation-delay: 0.03s;
+  -moz-animation-delay: 0.03s;
+  -o-animation-delay: 0.03s;
+  animation-delay: 0.03s;
+}
+
+.la-ball-grid-beat > div:nth-child(2) {
+  -webkit-animation-duration: 1.02s;
+  -moz-animation-duration: 1.02s;
+  -o-animation-duration: 1.02s;
+  animation-duration: 1.02s;
+  -webkit-animation-delay: 0.09s;
+  -moz-animation-delay: 0.09s;
+  -o-animation-delay: 0.09s;
+  animation-delay: 0.09s;
+}
+
+.la-ball-grid-beat > div:nth-child(3) {
+  -webkit-animation-duration: 1.06s;
+  -moz-animation-duration: 1.06s;
+  -o-animation-duration: 1.06s;
+  animation-duration: 1.06s;
+  -webkit-animation-delay: -0.69s;
+  -moz-animation-delay: -0.69s;
+  -o-animation-delay: -0.69s;
+  animation-delay: -0.69s;
+}
+
+.la-ball-grid-beat > div:nth-child(4) {
+  -webkit-animation-duration: 1.5s;
+  -moz-animation-duration: 1.5s;
+  -o-animation-duration: 1.5s;
+  animation-duration: 1.5s;
+  -webkit-animation-delay: -0.41s;
+  -moz-animation-delay: -0.41s;
+  -o-animation-delay: -0.41s;
+  animation-delay: -0.41s;
+}
+
+.la-ball-grid-beat > div:nth-child(5) {
+  -webkit-animation-duration: 1.6s;
+  -moz-animation-duration: 1.6s;
+  -o-animation-duration: 1.6s;
+  animation-duration: 1.6s;
+  -webkit-animation-delay: 0.04s;
+  -moz-animation-delay: 0.04s;
+  -o-animation-delay: 0.04s;
+  animation-delay: 0.04s;
+}
+
+.la-ball-grid-beat > div:nth-child(6) {
+  -webkit-animation-duration: 0.84s;
+  -moz-animation-duration: 0.84s;
+  -o-animation-duration: 0.84s;
+  animation-duration: 0.84s;
+  -webkit-animation-delay: 0.07s;
+  -moz-animation-delay: 0.07s;
+  -o-animation-delay: 0.07s;
+  animation-delay: 0.07s;
+}
+
+.la-ball-grid-beat > div:nth-child(7) {
+  -webkit-animation-duration: 0.68s;
+  -moz-animation-duration: 0.68s;
+  -o-animation-duration: 0.68s;
+  animation-duration: 0.68s;
+  -webkit-animation-delay: -0.66s;
+  -moz-animation-delay: -0.66s;
+  -o-animation-delay: -0.66s;
+  animation-delay: -0.66s;
+}
+
+.la-ball-grid-beat > div:nth-child(8) {
+  -webkit-animation-duration: 0.93s;
+  -moz-animation-duration: 0.93s;
+  -o-animation-duration: 0.93s;
+  animation-duration: 0.93s;
+  -webkit-animation-delay: -0.76s;
+  -moz-animation-delay: -0.76s;
+  -o-animation-delay: -0.76s;
+  animation-delay: -0.76s;
+}
+
+.la-ball-grid-beat > div:nth-child(9) {
+  -webkit-animation-duration: 1.24s;
+  -moz-animation-duration: 1.24s;
+  -o-animation-duration: 1.24s;
+  animation-duration: 1.24s;
+  -webkit-animation-delay: -0.76s;
+  -moz-animation-delay: -0.76s;
+  -o-animation-delay: -0.76s;
+  animation-delay: -0.76s;
+}
+
+.la-ball-grid-beat.la-sm {
+  width: 18px;
+  height: 18px;
+}
+
+.la-ball-grid-beat.la-sm > div {
+  width: 4px;
+  height: 4px;
+  margin: 1px;
+}
+
+.la-ball-grid-beat.la-2x {
+  width: 72px;
+  height: 72px;
+}
+
+.la-ball-grid-beat.la-2x > div {
+  width: 16px;
+  height: 16px;
+  margin: 4px;
+}
+
+.la-ball-grid-beat.la-3x {
+  width: 108px;
+  height: 108px;
+}
+
+.la-ball-grid-beat.la-3x > div {
+  width: 24px;
+  height: 24px;
+  margin: 6px;
+}
+
+/*
+  * Animation
+  */
+@-webkit-keyframes ball-grid-beat {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.35;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@-moz-keyframes ball-grid-beat {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.35;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@-o-keyframes ball-grid-beat {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.35;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes ball-grid-beat {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.35;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,44 +1,18 @@
 <!DOCTYPE html>
 <html lang="en" style="height:100%">
-
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="theme-color" content="#000000">
-  <!--
-      manifest.json provides metadata used when your web app is added to the
-      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
-    -->
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
   <link rel="stylesheet" href="%PUBLIC_URL%/index.css">
-  <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
   <title>Battlesnake</title>
 </head>
-
 <body style="margin:0;padding:0;height:100%">
   <noscript>
     You need to enable JavaScript to run this app.
   </noscript>
   <div id="root" style="height:100%"></div>
-  <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
 </body>
-
 </html>

--- a/src/components/game.jsx
+++ b/src/components/game.jsx
@@ -19,6 +19,14 @@ const PageWrapper = styled("div")`
       : "transparent"};
 `;
 
+const LoadingIndicator = styled("div")({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  height: "100%",
+  width: "100%"
+});
+
 const GameBoardWrapper = styled("div")({
   display: "flex",
   justifyContent: "space-between",
@@ -27,12 +35,12 @@ const GameBoardWrapper = styled("div")({
   height: "100%"
 });
 
-const BoardWrapper = styled("div")({
+const BoardWrapper = styled("div")(({ hideScoreboard }) => ({
   display: "flex",
   flexDirection: "column",
-  width: "65vw",
+  width: hideScoreboard ? "100%" : "65vw",
   height: "100%"
-});
+}));
 
 const ScoreboardWrapper = styled("div")({
   width: "35vw",
@@ -48,6 +56,7 @@ class Game extends React.Component {
       : themes.light;
 
     if (options.game && options.engine) {
+      this.hideScoreboard = this.props.options.hideScoreboard === "true";
       this.props.setEngineOptions(options);
       this.props.fetchFrames();
     } else {
@@ -64,14 +73,33 @@ class Game extends React.Component {
       return this.renderGame();
     }
 
-    return <div>Loading game...</div>;
+    return (
+      <LoadingIndicator>
+        <div
+          className="la-ball-grid-beat la-dark"
+          style={{
+            color: "#ff5c75"
+          }}
+        >
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+        </div>
+      </LoadingIndicator>
+    );
   }
 
   renderGame() {
     return (
       <PageWrapper theme={this.theme}>
         <GameBoardWrapper>
-          <BoardWrapper>
+          <BoardWrapper hideScoreboard={this.hideScoreboard}>
             <Board
               snakes={this.props.currentFrame.snakes}
               food={this.props.currentFrame.food}
@@ -90,7 +118,7 @@ class Game extends React.Component {
               paused={this.props.paused}
             />
           </BoardWrapper>
-          {this.props.options.hideScoreboard !== "true" && (
+          {!this.hideScoreboard && (
             <ScoreboardWrapper>
               <Scoreboard
                 turn={this.props.currentFrame.turn}

--- a/src/components/game.jsx
+++ b/src/components/game.jsx
@@ -76,9 +76,9 @@ class Game extends React.Component {
     return (
       <LoadingIndicator>
         <div
-          className="la-ball-grid-beat la-dark"
+          className="la-ball-grid-beat la-dark la-2x"
           style={{
-            color: "#ff5c75"
+            color: colors.food
           }}
         >
           <div />


### PR DESCRIPTION
The scoreboard was hidden with the `hideScoreboard` querystring param, however the Board was still set to only use 65% of the viewport width. This PR ensures that when the Scoreboard component is hidden from view that the board consumes 100% of the viewport width.

Also adds a sweet animated loader instead of the boring "Loading Game..." text.

![loader](https://user-images.githubusercontent.com/1509352/52657519-b60c7380-2ead-11e9-95ec-44157b1b7fad.gif)
