### PR TITLE
Remnant leftover from previous PR

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -145,7 +145,7 @@ export const toggleGamePause = () => {
       dispatch(resumeGame());
       dispatch(playFromFrame(currentFrame));
     } else {
-      dispatch(setTurnCount(currentFrame.turn + 1));
+      dispatch(setTurnCount(currentFrame.turn));
       dispatch(pauseGame());
     }
   };


### PR DESCRIPTION
Play used to do math to calculate the turn, but now it just takes the raw value from Board. This was a remnant leftover from me removing the math from Play but not removing from Board here.