### PR TITLE
Tweak loading of long games when sharing game by turn number

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -66,25 +66,24 @@ export const fetchFrames = () => {
       // Workaround for bug where turn exluded on turn 0
       frame.Turn = frame.Turn || 0;
       dispatch(receiveFrame(game, frame));
-
-      // Workaround to render the first frame into the board
-      if (frame.Turn === 0) {
-        const frame = getState().frames[0];
-        dispatch(setCurrentFrame(frame));
-      }
     });
 
-    if (autoplay) {
-      const frame = getState().frames[0];
-      dispatch(resumeGame());
-      dispatch(playFromFrame(frame));
-    }
+    const { frames } = getState();
+
+    // Get the first frame by default
+    let frame = frames[0];
 
     // Only navigate to the specified frame if it is within the
     // amount of frames available in the game
     if (turn && turn <= getState().frames.length) {
-      const frame = getState().frames[turn];
-      dispatch(setCurrentFrame(frame));
+      frame = frames[turn];
+    }
+
+    dispatch(setCurrentFrame(frame));
+
+    if (autoplay) {
+      dispatch(resumeGame());
+      dispatch(playFromFrame(frame));
     }
   };
 };

--- a/src/components/game.jsx
+++ b/src/components/game.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "react-emotion";
 
 import BlankState from "./blank-state";
+import LoadingIndicator from "./loading-indicator";
 import Board from "./board";
 import Scoreboard from "./scoreboard";
 import MediaControls from "./mediaControls";
@@ -18,14 +19,6 @@ const PageWrapper = styled("div")`
       ? `linear-gradient(45deg, #000 0%, ${colors.purple} 100%)`
       : "transparent"};
 `;
-
-const LoadingIndicator = styled("div")({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  height: "100%",
-  width: "100%"
-});
 
 const GameBoardWrapper = styled("div")({
   display: "flex",
@@ -73,34 +66,17 @@ class Game extends React.Component {
   }
 
   render() {
+    const { currentFrame } = this.props;
+
     if (this.invalidArgs) {
       return <BlankState />;
     }
 
-    if (this.props.currentFrame) {
+    if (currentFrame) {
       return this.renderGame();
     }
 
-    return (
-      <LoadingIndicator>
-        <div
-          className="la-ball-grid-beat la-dark la-2x"
-          style={{
-            color: colors.food
-          }}
-        >
-          <div />
-          <div />
-          <div />
-          <div />
-          <div />
-          <div />
-          <div />
-          <div />
-          <div />
-        </div>
-      </LoadingIndicator>
-    );
+    return <LoadingIndicator />;
   }
 
   renderGame() {

--- a/src/components/loading-indicator.jsx
+++ b/src/components/loading-indicator.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import styled from "react-emotion";
+
+import { colors } from "../theme";
+
+const LoadingIndicatorWrapper = styled("div")({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  height: "100%",
+  width: "100%"
+});
+
+class LoadingIndicator extends React.Component {
+  render() {
+    return (
+      <LoadingIndicatorWrapper>
+        <div
+          className="la-ball-grid-beat la-dark la-2x"
+          style={{
+            color: colors.food
+          }}
+        >
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+        </div>
+      </LoadingIndicatorWrapper>
+    );
+  }
+}
+
+export default LoadingIndicator;


### PR DESCRIPTION
Shows the loader until we render the correctly specified frame on long games.