### PR TITLE
Oops. Forgot this needs to live in the wrapper class for querystring hiding

### DIFF
--- a/src/components/mediaControls.jsx
+++ b/src/components/mediaControls.jsx
@@ -5,6 +5,7 @@ import KeyboardEventHandler from "react-keyboard-event-handler";
 import { themes, breakpoints } from "../theme";
 
 const MediaControlsWrapper = styled("div")`
+  display: ${({ hide }) => (hide ? "none" : "block")};
   margin-top: 1rem;
   width: 100%;
 `;


### PR DESCRIPTION
This allows the querystring param to work to hide the media controls