### PR TITLE
Handle parent frame keyboard events better

### DIFF
--- a/src/components/mediaControls.jsx
+++ b/src/components/mediaControls.jsx
@@ -105,7 +105,12 @@ class MediaControls extends React.Component {
   };
 
   componentWillMount() {
-    this.keyEvents = ["r", "left", "right", "space"];
+    this.keyboardCodeMap = {
+      KeyR: "r",
+      ArrowLeft: "left",
+      ArrowRight: "right",
+      Space: "space"
+    };
   }
 
   componentDidMount() {
@@ -121,13 +126,8 @@ class MediaControls extends React.Component {
   }
 
   handleParentKeyboardEvent = e => {
-    const { keyCode } = e.data;
-    const keyboardEvent = new KeyboardEvent("keydown", {
-      bubbles: true,
-      cancelable: true,
-      keyCode
-    });
-    document.body.dispatchEvent(keyboardEvent);
+    const { code } = e.data;
+    this.handleKeyEvent(this.keyboardCodeMap[code]);
   };
 
   handleReload = () => {
@@ -199,7 +199,7 @@ class MediaControls extends React.Component {
             Forward
           </Button>
           <KeyboardEventHandler
-            handleKeys={this.keyEvents}
+            handleKeys={Object.values(this.keyboardCodeMap)}
             onKeyEvent={this.handleKeyEvent}
           />
           <KeyboardShortcutsWrapper>


### PR DESCRIPTION
This uses the internal Redux actions rather than simulating KeyboardEvents which was not ideal.