### PR TITLE
Refactor the direction calculation to account for early food

### DIFF
--- a/src/utils/game-state.js
+++ b/src/utils/game-state.js
@@ -97,20 +97,11 @@ function shouldRenderPart(snake, partIndex) {
 
 function formatSnakePart(snake, partIndex) {
   const part = snake.Body[partIndex];
-  const nextPart = snake.Body[partIndex - 1];
   const shouldRender = shouldRenderPart(snake, partIndex);
   const type = getType(snake, partIndex);
   const { x, y } = formatPosition(part);
-  const direction = nextPart
-    ? // NOTE: This logic is tricky but prevents the last body part
-      // from covering the tail after eating.
-      // If the current part is in the same coordinates as the previous part
-      // and has a type of TYPE_TAIL, then we use the direction of 2 parts away.
-      // Otherwise, just calculate the direction given the current and next parts.
-      part.X === nextPart.X && part.Y === nextPart.Y && type === TYPE_TAIL
-      ? getDirection(part, snake.Body[partIndex - 2])
-      : getDirection(part, nextPart)
-    : headDirection(snake);
+  const direction = formatDirection(type, snake, part);
+
   return {
     direction,
     shouldRender,
@@ -129,6 +120,27 @@ function formatPosition(pos) {
     x: pos.X,
     y: pos.Y
   };
+}
+
+function formatDirection(type, snake, part) {
+  let direction;
+  if (type === "head") {
+    direction = headDirection(snake);
+  } else {
+    // Determine a part's direction by the unique points (x,y)
+    // occupied by the snake.
+    const uniquePoints = [...new Set(snake.Body.map(p => `${p.X},${p.Y}`))];
+    const uniqueIndex = uniquePoints.findIndex(
+      p => p === `${part.X},${part.Y}`
+    );
+
+    direction = getDirection(
+      snake.Body[uniqueIndex],
+      snake.Body[Math.max(uniqueIndex - 1, 0)]
+    );
+  }
+
+  return direction;
 }
 
 function getDirection(a, b) {


### PR DESCRIPTION
# Summary

The issue was pointned out in slack [here](https://battlesnake.slack.com/archives/C481H117Z/p1551144495047700) by ryan: "Hey guys I saw a post awhile ago about fixing the bug with tails when eating food/start. Noticed a new bug relating to that."

And a screenshot was provided: 

![image](https://user-images.githubusercontent.com/3220620/53462730-b6eaec80-39f9-11e9-95e5-94cdc75c18bf.png)

# Solution (the commit message)

The way we were calculating the direction didn't account for initial conditions where body parts overlap. This caused the tail to be rendered in the incorrect direction. As a fix, we looked at the partIndex - 2, which was equivalently the head of the snake, when determining the
direction.

This works, except when a snake eats food in the first turn. Now an index offset of -2 doesn't refer to the head of the snake.

As a refactor, use the unique coordinates occupied by a snake for the direction calculation. As an example: even if a snake has a body length of 3, after the first move it will only occupy two spots on the board. And so we treat it as a snake of length 2 when calculating direction.