### PR TITLE
Detect if head is on top of body and don't render body segment underneath

### DIFF
--- a/src/utils/game-state.js
+++ b/src/utils/game-state.js
@@ -96,6 +96,7 @@ function shouldRenderPart(snake, partIndex) {
   const nextPart = snake.Body[partIndex - 1];
   return (
     !(tail.X === currPart.X && tail.Y === currPart.Y) &&
+    !(head.X === currPart.X && head.Y === currPart.Y) &&
     !(nextPart && nextPart.X === currPart.X && nextPart.Y === currPart.Y)
   );
 }

--- a/src/utils/game-state.test.js
+++ b/src/utils/game-state.test.js
@@ -408,7 +408,7 @@ describe("should expect tail to be rendered after eating food", () => {
   });
 });
 
-it("should expect correctly rendered snake parts after crashing into self", () => {
+it("should expect correctly rendered snake parts after crashing into body segment of self", () => {
   const apiFrame = {
     Turn: 29,
     Food: [{ X: 4, Y: 9 }],
@@ -452,6 +452,64 @@ it("should expect correctly rendered snake parts after crashing into self", () =
       { x: 5, y: 5, direction: "down", type: "tail" }
     ],
     death: { cause: "self-collision", turn: 29 },
+    isDead: true,
+    head: undefined,
+    tail: undefined,
+    headSvg: undefined,
+    tailSvg: undefined
+  });
+});
+
+it("should expect correctly rendered snake parts after going backwards into body", () => {
+  const apiFrame = {
+    Turn: 50,
+    Food: [{ X: 8, Y: 11 }],
+    Snakes: [
+      {
+        ID: "snake1",
+        Name: "snake 1",
+        URL: "http://snake1",
+        Health: 80,
+        Death: { Cause: "self-collision", Turn: 50 },
+        Color: "red",
+        Body: [
+          { X: 0, Y: 10 },
+          { X: 0, Y: 11 },
+          { X: 0, Y: 10 },
+          { X: 0, Y: 9 },
+          { X: 0, Y: 8 },
+          { X: 1, Y: 8 },
+          { X: 1, Y: 9 },
+          { X: 1, Y: 10 }
+        ]
+      }
+    ]
+  };
+
+  const frame = formatFrame(apiFrame);
+
+  expect(frame.turn).toBe(50);
+  expect(frame.snakes).toHaveLength(1);
+  expect(frame.food).toHaveLength(1);
+
+  expect(frame.food[0]).toEqual({ x: 8, y: 11 });
+
+  expect(frame.snakes[0]).toEqual({
+    _id: "snake1",
+    name: "snake 1",
+    health: 80,
+    color: "red",
+    body: [
+      { x: 0, y: 10, direction: "up", type: "head" },
+      { x: 0, y: 11, direction: "down", type: "body" },
+      { x: 0, y: 10, direction: "down", type: "body" },
+      { x: 0, y: 9, direction: "down", type: "body" },
+      { x: 0, y: 8, direction: "down", type: "body" },
+      { x: 1, y: 8, direction: "left", type: "body" },
+      { x: 1, y: 9, direction: "up", type: "body" },
+      { x: 1, y: 10, direction: "up", type: "tail" }
+    ],
+    death: { cause: "self-collision", turn: 50 },
     isDead: true,
     head: undefined,
     tail: undefined,

--- a/src/utils/game-state.test.js
+++ b/src/utils/game-state.test.js
@@ -501,12 +501,11 @@ it("should expect correctly rendered snake parts after going backwards into body
     color: "red",
     body: [
       { x: 0, y: 10, direction: "up", type: "head" },
-      { x: 0, y: 11, direction: "down", type: "body" },
-      { x: 0, y: 10, direction: "down", type: "body" },
+      { x: 0, y: 11, direction: "up", type: "body" },
       { x: 0, y: 9, direction: "down", type: "body" },
       { x: 0, y: 8, direction: "down", type: "body" },
-      { x: 1, y: 8, direction: "left", type: "body" },
-      { x: 1, y: 9, direction: "up", type: "body" },
+      { x: 1, y: 8, direction: "down", type: "body" },
+      { x: 1, y: 9, direction: "left", type: "body" },
       { x: 1, y: 10, direction: "up", type: "tail" }
     ],
     death: { cause: "self-collision", turn: 50 },


### PR DESCRIPTION
This fixes a case where a self collision causes a dead snake to look like it "blew apart" (the body segments and tail are in weird directions after death).

![Kapture 2019-03-11 at 13 42 52](https://user-images.githubusercontent.com/1509352/54156486-9a8c7e00-4403-11e9-9d0b-341005d61cd7.gif)